### PR TITLE
Run syn on a remote server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ ui/node
 .hc*
 *.happ
 .cargo
+/tmp/*
+
+# Negative ignores last:
+!.gitkeep

--- a/bin/dev.sh
+++ b/bin/dev.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Usage:
+# bin/dev.sh [number of sandboxes]
+#
+# this will start hc nodes on ports 8000, 8001, 8002...
+# and since hc binds to localhost,
+# we expose them via socat on 9000, 9001, 9002...
+
+set -euo pipefail
+
+# example:
+# die "exit with this error message"
+die() { echo "$*" 1>&2 ; exit 1; }
+
+nuke() {
+  name=$1
+  ( set -x && killall -9 $name ) || true
+}
+
+. ~/.nix-profile/etc/profile.d/nix.sh
+
+if [ "$(uname)" == "Darwin" ]; then
+  nix_cmd="nix-shell default-osx.nix"
+else
+  nix_cmd="nix-shell"
+fi
+
+which socat || die "ERROR: executable 'socat' not found in PATH: $PATH"
+( set -x && ${nix_cmd} --run "pwd" ) # load up all nix-shell deps etc, which can take a long time upon changes, before killing anything
+
+nuke hc
+nuke holochain
+nuke lair-keystore
+nuke socat
+
+sandboxes=${1:-2}
+port_increment=1
+min_port=8000
+max_port=$(( min_port + (sandboxes - 1) * port_increment ))
+
+for localhost_port in $(seq $min_port $port_increment $max_port); do
+  exposed_port=$(( localhost_port + 1000 ))
+  ( set -x && socat TCP-LISTEN:${exposed_port},fork,reuseaddr TCP:127.0.0.1:${localhost_port} & )
+done
+
+ports=$(seq -s , $min_port $port_increment $max_port)
+
+hc_command=$( echo "
+hc sandbox generate
+  --run ${ports}
+  --app-id syn
+  --num-sandboxes ${sandboxes}
+  --root tmp
+  network
+    --bootstrap https://bootstrap-staging.holo.host
+    quic
+  " | tr '\n' ' ' | tr -s ' ' )
+
+set -x
+${nix_cmd} --run "${hc_command}"

--- a/default-osx.nix
+++ b/default-osx.nix
@@ -1,0 +1,21 @@
+let
+  holonixPath = builtins.fetchTarball {
+    url = "https://github.com/holochain/holonix/archive/refs/heads/experiment/holochain-darwin-ldflags.tar.gz";
+    sha256 = "1765x81nkm79fn98kv782wr6amj2vaxccp9l4ppv8h1lhfvapbgp";
+  };
+  holonix = import (holonixPath) {
+    includeHolochainBinaries = true;
+    holochainVersionId = "custom";
+
+    holochainVersion = {
+      rev = "78e2591449f1467f32b24219b4ffac75b6b840ee";
+      sha256 = "10znmmxba2n74np8kriwwbk977x9asq7abbjz5w8angzi1nhibfm";
+      cargoSha256 = "1hdnfzn9nlfa5wb2xhk2h7myb21gbiilk8v4jm8sqcf5pjjk5x2j";
+      bins = {
+        holochain = "holochain";
+        hc = "hc";
+      };
+    };
+    holochainOtherDepsNames = ["lair-keystore"];
+  };
+in holonix.main

--- a/infra/systemd/README.md
+++ b/infra/systemd/README.md
@@ -1,0 +1,19 @@
+To install, cd to this directory and:
+
+```sh
+sudo ln -sf `pwd`/syn.service /etc/systemd/system/syn.service
+```
+
+After changing, reload and start:
+
+```sh
+sudo systemctl daemon-reload
+sudo systemctl start syn.service
+sudo systemctl status syn.service
+```
+
+To see full logs of this service:
+
+```sh
+journalctl -u syn.service
+```

--- a/infra/systemd/syn.service
+++ b/infra/systemd/syn.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Start Syn
+
+[Service]
+User=dev
+WorkingDirectory=/home/dev/syn
+ExecStart=/home/dev/syn/bin/dev.sh 2
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/ui/rollup.config.js
+++ b/ui/rollup.config.js
@@ -39,7 +39,8 @@ export default {
 	},
 	plugins: [
 	  replace({
-            'process.env.NODE_ENV': JSON.stringify(process.env.NODE)
+            'process.env.NODE_ENV': JSON.stringify(process.env.NODE),
+            'process.env.APP_HOST': JSON.stringify(process.env.APP_HOST)
           }),
 	  svelte({
 			compilerOptions: {

--- a/ui/src/Syn.svelte
+++ b/ui/src/Syn.svelte
@@ -21,12 +21,12 @@
 
   const dispatch = createEventDispatcher()
 
-  let adminPort=1234
+  let appHost= process.env.APP_HOST || 'localhost'
   let appPort=8888
   let appId='syn'
   async function toggle() {
     if (!$connection) {
-      $connection = new Connection(appPort, appId)
+      $connection = new Connection(appHost, appPort, appId)
       await $connection.open({title:'', body:''}, applyDeltaFn)
 
       session = $connection.syn.session
@@ -82,7 +82,8 @@
 
 <div>
   <h4>Holochain Connection:</h4>
-  App Port: <input bind:value={appPort}>
+  Host: <input bind:value={appHost}>
+  Port: <input bind:value={appPort}>
   AppId: <input bind:value={appId}>
   <button on:click={toggle}>
     {#if $connection}

--- a/ui/src/syn.js
+++ b/ui/src/syn.js
@@ -637,7 +637,8 @@ export class Session {
 }
 
 export class Connection {
-  constructor(appPort, appId) {
+  constructor(appHost, appPort, appId) {
+    this.appHost = appHost;
     this.appPort = appPort;
     this.appId = appId;
     this.sessions = []
@@ -646,7 +647,7 @@ export class Connection {
   async open(defaultContent, applyDeltaFn) {
     var self = this;
     this.appClient = await AppWebsocket.connect(
-      `ws://localhost:${this.appPort}`,
+      `ws://${this.appHost}:${this.appPort}`,
       30000,
       (signal) => signalHandler(self, signal))
 


### PR DESCRIPTION
# Context

In order to facilitate multi-user exploration of syn, without the use of ngrok or similar, I wanted to launch an external linux server and run the server component of syn there. 

# Changes

- To make this work with the web UI, I added a "host" field to the interface to allow the UI to connect to any host, not just localhost.  _Note: I have not yet tried this within the electron context_.
- While one can manually start `hc sandbox ...` (or `holochain ...`) for each node on their server, we simplify this by adding a script (`bin/dev.sh`) which: 
  1. aggressively kills any existing (presumed orphan) processes (hc, lair, etc)
  1. starts however many servers you specify via `hc sandbox ...`
  1. start hc nodes on ports 8000, 8001, 8002...
  1. and since hc binds to localhost only, we expose these servers via socat on 9000, 9001, 9002...
- We also add a working nix config for OSX, and use that in the above script, if we are running on OSX.
- We add a systemd syn.service startup file, so that we can run the script in the background, restart on crash or reboot, etc  
